### PR TITLE
Set DesktopShim target to 10.13

### DIFF
--- a/SpriteKitWatchFace.xcodeproj/project.pbxproj
+++ b/SpriteKitWatchFace.xcodeproj/project.pbxproj
@@ -717,7 +717,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				PRODUCT_BUNDLE_IDENTIFIER = com.highcaffeinecontent.SKWFDesktopShim;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;


### PR DESCRIPTION
Tested and works fine on 10.13, but some of us can't upgrade to Mojave. So setting this for us less fortunate souls.