### PR TITLE
Correct scaling on simulator Fixes #17

### DIFF
--- a/SpriteKitWatchFace WatchKit Extension/InterfaceController.m
+++ b/SpriteKitWatchFace WatchKit Extension/InterfaceController.m
@@ -36,7 +36,7 @@
 	
 	/* Using the 44mm Apple Watch as the base size, scale down to fit */
 	scene.camera.xScale = (184.0/currentDeviceSize.width);
-	scene.camera.yScale = (184.0/currentDeviceSize.width);
+        scene.camera.yScale = (224.0/currentDeviceSize.height);
 	
 	[self.scene presentScene:scene];
 }


### PR DESCRIPTION
while scaling based on either the shortest or longest side in both dimensions makes sense to me (to maintain aspect ratios) it seems to be leading to an odd crop / black bar on my Series 4 simulator.

Changing the yScale to be a proportion of 224 / device height seems to correct this issue: https://github.com/steventroughtonsmith/SpriteKitWatchFace/issues/17